### PR TITLE
fix #15

### DIFF
--- a/source/scid/bindings/lapack/dlapack.d
+++ b/source/scid/bindings/lapack/dlapack.d
@@ -3198,12 +3198,13 @@ f_double dlamch(char[]cmach) {
     return dlamch_(cmach.ptr, toInt(cmach.length));
 }
 
-///
-lapack_float_ret_t second() {
-    return second_();
+version(netlib_clapack)
+{
+    ///
+    lapack_float_ret_t second() {
+        return second_();
+    }
+    f_double secnd() {
+        return dsecnd_();
+    }
 }
-f_double secnd() {
-    return dsecnd_();
-}
-
-

--- a/source/scid/bindings/lapack/lapack.d
+++ b/source/scid/bindings/lapack/lapack.d
@@ -1722,8 +1722,9 @@ void ilaenvset_(f_int *ispec, char *name, char *opts, f_int *n1, f_int *n2, f_in
 f_float slamch_(char *cmach, f_int cmach_len);
 f_double dlamch_(char *cmach, f_int cmach_len);
 
-///
-lapack_float_ret_t second_();
-f_double dsecnd_();
-
-
+version(netlib_clapack)
+{
+    ///
+    lapack_float_ret_t second_();
+    f_double dsecnd_();
+}


### PR DESCRIPTION
`second_ ` and `dsecnd_ `  functions was
[removed](https://developer.apple.com/library/mac/releasenotes/General/MacOSXLionAPIDiffs/Accelerate.html) from default lapack on OS X.